### PR TITLE
fix: Export Prometheus metrics again

### DIFF
--- a/trino-lb/src/metrics.rs
+++ b/trino-lb/src/metrics.rs
@@ -131,7 +131,7 @@ impl Metrics {
         let trino_cluster_groups = config.trino_cluster_groups.clone();
         let persistence_clone = Arc::clone(&persistence);
         std::thread::spawn(move || {
-            let metrics_runtime = Builder::new_current_thread().build().unwrap();
+            let metrics_runtime = Builder::new_current_thread().enable_all().build().unwrap();
             metrics_runtime.block_on(queued_query_counts_metrics_handler(
                 ping_receiver,
                 metrics_sender,
@@ -170,7 +170,7 @@ impl Metrics {
         let trino_cluster_groups = config.trino_cluster_groups.clone();
         let persistence_clone = Arc::clone(&persistence);
         std::thread::spawn(move || {
-            let metrics_runtime = Builder::new_current_thread().build().unwrap();
+            let metrics_runtime = Builder::new_current_thread().enable_all().build().unwrap();
             metrics_runtime.block_on(cluster_counts_per_state_metrics_handler(
                 ping_receiver,
                 metrics_sender,


### PR DESCRIPTION
Fixes
```
thread '<unnamed>' panicked at /home/sbernauer/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.37.0/src/time/sleep.rs:309:9:
A Tokio 1.x context was found, but timers are disabled. Call `enable_time` on the runtime builder to enable timers.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread '<unnamed>' panicked at trino-lb/src/metrics.rs:147:82:
called `Option::unwrap()` on a `None` value
thread 'tokio-runtime-worker' panicked at trino-lb/src/metrics.rs:149:26:
called `Result::unwrap()` on an `Err` value: Any { .. }
```