### PR TITLE
fix: Use Redis ConnectionManager to reconnect on failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-### Changed
+### Fixed
 
-- Bump Rust dependency versions ([#19]).
-
-[#19]: https://github.com/stackabletech/trino-lb/pull/19
+- Use redis `ConenctionManager`´to re-connect on Redis conenctino failures. Previously trino-lb would stop working once
+  the Redis Pod restarted ([#XX]).
 
 ## [0.2.0] - 2024-04-07
 
 ### Added
 
 - BREAKING: Add support for single instance redis persistence (without Redis cluster mode).
-  This is breaking, because you need to set `trinoLb.persistence.redis.clusterMode: true` in your config to keep using the cluster mode ([#15]).
+  This is breaking, because you need to set `trinoLb.persistence.redis.clusterMode: true` in your config to keep using
+  the cluster mode ([#15]).
 
 [#15]: https://github.com/stackabletech/trino-lb/pull/15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Use redis [`ConnectionManager`](https://docs.rs/redis/latest/redis/aio/struct.ConnectionManager.html) to re-connect on
+- Use redis [`ConnectionManager`](https://docs.rs/redis/latest/redis/aio/struct.ConnectionManager.html) to reconnect on
   Redis connection failures. Previously trino-lb would stop working once the Redis Pod restarted. This change only
   affects the single Redis instance connection, *not* the cluster mode connection, as a
   [ClusterConnection](https://docs.rs/redis/latest/redis/cluster/struct.ClusterConnection.html) does not seem to support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Use redis `ConenctionManager` to re-connect on Redis connection failures. Previously trino-lb would stop working once
-  the Redis Pod restarted ([#34]).
+- Use redis [`ConnectionManager`](https://docs.rs/redis/latest/redis/aio/struct.ConnectionManager.html) to re-connect on
+  Redis connection failures. Previously trino-lb would stop working once the Redis Pod restarted. This change only
+  affects the single Redis instance connection, *not* the cluster mode connection, as a
+  [ClusterConnection](https://docs.rs/redis/latest/redis/cluster/struct.ClusterConnection.html) does not seem to support
+  a [`ConnectionManager`](https://docs.rs/redis/latest/redis/aio/struct.ConnectionManager.html) ([#34]).
 
 [#34]: https://github.com/stackabletech/trino-lb/pull/34
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Use redis `ConenctionManager`´to re-connect on Redis conenctino failures. Previously trino-lb would stop working once
-  the Redis Pod restarted ([#XX]).
+- Use redis `ConenctionManager` to re-connect on Redis connection failures. Previously trino-lb would stop working once
+  the Redis Pod restarted ([#34]).
+
+[#34]: https://github.com/stackabletech/trino-lb/pull/34
 
 ## [0.2.0] - 2024-04-07
 

--- a/trino-lb-persistence/src/lib.rs
+++ b/trino-lb-persistence/src/lib.rs
@@ -88,7 +88,7 @@ pub trait Persistence {
 
 #[enum_dispatch]
 pub enum PersistenceImplementation {
-    Redis(redis::RedisPersistence<::redis::aio::MultiplexedConnection>),
+    Redis(redis::RedisPersistence<::redis::aio::ConnectionManager>),
     RedisCluster(
         redis::RedisPersistence<
             ::redis::cluster_async::ClusterConnection<::redis::aio::MultiplexedConnection>,

--- a/trino-lb/src/main.rs
+++ b/trino-lb/src/main.rs
@@ -116,7 +116,7 @@ async fn start() -> Result<(), MainError> {
                     .context(CreateRedisPersistenceClientSnafu)?
                     .into()
                 } else {
-                    RedisPersistence::<::redis::aio::MultiplexedConnection>::new(
+                    RedisPersistence::<::redis::aio::ConnectionManager>::new(
                         redis_config,
                         cluster_groups,
                     )


### PR DESCRIPTION
Previously trino-lb would not recover from a closed connection

```
2024-06-21T08:00:17.924954Z  INFO Fetching current query counters: trino_lb::maintenance::query_count_fetcher: QueryCountFetcher: Updated query counters from 1 remote clusters
2024-06-21T08:00:22.720512Z ERROR Fetching current query counters: trino_lb::maintenance::query_count_fetcher: QueryCountFetcher: Failed to get last QueryCountFetcher update timestamp err=RedisError { source: GetLastQueryCountFetcherUpdate { source: broken pipe } }
2024-06-21T08:00:27.719737Z ERROR Fetching current query counters: trino_lb::maintenance::query_count_fetcher: QueryCountFetcher: Failed to get last QueryCountFetcher update timestamp err=RedisError { source: GetLastQueryCountFetcherUpdate { source: broken pipe } }
2024-06-21T08:00:32.720312Z ERROR Fetching current query counters: trino_lb::maintenance::query_count_fetcher: QueryCountFetcher: Failed to get last QueryCountFetcher update timestamp err=RedisError { source: GetLastQueryCountFetcherUpdate { source: broken pipe } }
```

Now the first call to redis will fail, but the following calls will work again

```
2024-06-21T07:58:57.264989Z  INFO Fetching current query counters: trino_lb::maintenance::query_count_fetcher: QueryCountFetcher: Updated query counters from 1 remote clusters
2024-06-21T07:59:02.085295Z ERROR Fetching current query counters: trino_lb::maintenance::query_count_fetcher: QueryCountFetcher: Failed to get last QueryCountFetcher update timestamp err=RedisError { source: GetLastQueryCountFetcherUpdate { source: broken pipe } }
2024-06-21T07:59:07.086128Z  INFO Fetching current query counters: trino_lb::maintenance::query_count_fetcher: QueryCountFetcher: Updated query counters from 0 remote clusters
2024-06-21T07:59:12.085915Z  INFO Fetching current query counters: trino_lb::maintenance::query_count_fetcher: QueryCountFetcher: Updated query counters from 0 remote clusters
```