### PR TITLE
fix: Install default crypto provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.3.1] - 2024-08-16
+
+### Fixed
+
+- Install default crypto provider, this prevent servers using https from starting ([#45]).
+
+[#45]: https://github.com/stackabletech/trino-lb/pull/45
+
 ## [0.3.0] - 2024-08-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4035,6 +4035,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.5",
  "rstest",
+ "rustls 0.23.12",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ reqwest = { version = "0.12", default-features = false, features = [
   "json",
   "cookies",
 ] }
+rustls = "0.23" # https://github.com/rustls/rustls/issues/1938
 rstest = "0.22"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/example-configs/simple-single-trino.yaml
+++ b/example-configs/simple-single-trino.yaml
@@ -1,10 +1,10 @@
 trinoLb:
-  externalAddress: https://127.0.0.1:443
+  externalAddress: https://127.0.0.1:8443
   # When you enable authentication trino-clients enforce https encryption
   tls:
     enabled: true
-    certPemFile: /self-signed-certs/cert.pem
-    keyPemFile: /self-signed-certs/key.pem
+    certPemFile: ./example-configs/self-signed-certs/cert.pem
+    keyPemFile: ./example-configs/self-signed-certs/key.pem
   # Use in-memory persistence which will loose all queued running queries on restart
   persistence:
     inMemory: {}

--- a/trino-lb/Cargo.toml
+++ b/trino-lb/Cargo.toml
@@ -39,6 +39,7 @@ rand.workspace = true
 redis.workspace = true
 regex.workspace = true
 reqwest.workspace = true
+rustls.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
 serde.workspace = true


### PR DESCRIPTION
Previously we where hitting
```
[2m2024-08-16T08:09:30.870088Z[0m [32m INFO[0m [2mtrino_lb::http_server[0m[2m:[0m Starting metrics exporter [3mlisten_addr[0m[2m=[0m[::]:9091
[2m2024-08-16T08:09:30.870166Z[0m [32m INFO[0m [2mtrino_lb::http_server[0m[2m:[0m Starting server [3mlisten_addr[0m[2m=[0m[::]:8444
thread 'main' panicked at /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rustls-0.23.12/src/crypto/mod.rs:259:14:
no process-level CryptoProvider available -- call CryptoProvider::install_default() before this point
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```