### PR TITLE
chore: Get rid of aws-lc-rs, as it broke the Tilt build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Don't use the `aws-lc-rs` crate (introduced in [#45]), as it broke the Tilt build ([#46]).
+
+[#46]: https://github.com/stackabletech/trino-lb/pull/46
+
 ## [0.3.1] - 2024-08-16
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,33 +201,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae74d9bd0a7530e8afd1770739ad34b36838829d6ad61818f9230f683f5ad77"
-dependencies = [
- "aws-lc-sys",
- "mirai-annotations",
- "paste",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0e249228c6ad2d240c2dc94b714d711629d52bad946075d8e9b2f5391f0703"
-dependencies = [
- "bindgen",
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
- "libc",
- "paste",
-]
-
-[[package]]
 name = "axum"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,29 +344,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bindgen"
-version = "0.69.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
-dependencies = [
- "bitflags 2.6.0",
- "cexpr",
- "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.74",
- "which",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,21 +387,11 @@ checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "cc"
-version = "1.1.10"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e8aabfac534be767c909e0690571677d49f41bd8465ae876fe043d52ba5292"
+checksum = "72db2f7947ecee9b03b510377e8bb9077afa27176fdbff55c51027e976fdcc48"
 dependencies = [
- "jobserver",
- "libc",
-]
-
-[[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
+ "shlex",
 ]
 
 [[package]]
@@ -498,21 +438,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
-]
-
-[[package]]
 name = "clap"
-version = "4.5.15"
+version = "4.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d8838454fda655dafd3accb2b6e2bea645b9e4078abe84a22ceb947235c5cc"
+checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -547,15 +476,6 @@ name = "clap_lex"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
-
-[[package]]
-name = "cmake"
-version = "0.1.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "colorchoice"
@@ -782,12 +702,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,12 +835,6 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1548,15 +1456,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -1569,15 +1468,6 @@ name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
-
-[[package]]
-name = "jobserver"
-version = "0.1.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "js-sys"
@@ -1743,26 +1633,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
-
-[[package]]
-name = "libloading"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
-dependencies = [
- "cfg-if",
- "windows-targets 0.52.6",
-]
+checksum = "a5f43f184355eefb8d17fc948dbecf6c13be3c141f20d834ae842193a448c72a"
 
 [[package]]
 name = "libm"
@@ -1881,12 +1755,6 @@ dependencies = [
  "wasi",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "mirai-annotations"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 
 [[package]]
 name = "nom"
@@ -2348,16 +2216,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
-dependencies = [
- "proc-macro2",
- "syn 2.0.74",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2544,7 +2402,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.0.0",
+ "rustc-hash",
  "rustls 0.23.12",
  "socket2",
  "thiserror",
@@ -2561,7 +2419,7 @@ dependencies = [
  "bytes",
  "rand",
  "ring",
- "rustc-hash 2.0.0",
+ "rustc-hash",
  "rustls 0.23.12",
  "slab",
  "thiserror",
@@ -2882,12 +2740,6 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
@@ -2932,7 +2784,6 @@ version = "0.23.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
 dependencies = [
- "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -2996,7 +2847,6 @@ version = "0.102.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3080,9 +2930,9 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.207"
+version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5665e14a49a4ea1b91029ba7d3bca9f299e1f7cfa194388ccc20f14743e784f2"
+checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
 dependencies = [
  "serde_derive",
 ]
@@ -3099,9 +2949,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.207"
+version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aea2634c86b0e8ef2cfdc0c340baede54ec27b1e46febd7f80dffb2aa44a00e"
+checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3110,9 +2960,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.124"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66ad62847a56b3dba58cc891acd13884b9c61138d330c0d7b6181713d4fce38d"
+checksum = "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
 dependencies = [
  "itoa",
  "memchr",
@@ -4035,7 +3885,6 @@ dependencies = [
  "regex",
  "reqwest 0.12.5",
  "rstest",
- "rustls 0.23.12",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -4359,18 +4208,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
-]
-
-[[package]]
 name = "whoami"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4614,17 +4451,3 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.74",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ repository = "https://github.com/stackabletech/trino-lb"
 
 [workspace.dependencies]
 axum = { version = "0.7", features = ["tracing"] }
-axum-server = { version = "0.7", features = ["tls-rustls"] }
+# If we use the feature "tls-rustls" it will pull in the "aws-lc-rs" crate, which as of 2024-08-16 I did not get to build in the "make run-dev" workflow :/
+axum-server = { version = "0.7", features = ["tls-rustls-no-provider"] }
 bincode = "1.3"
 chrono = "0.4"
 clap = { version = "4.5", features = ["derive"] }
@@ -63,7 +64,6 @@ reqwest = { version = "0.12", default-features = false, features = [
   "json",
   "cookies",
 ] }
-rustls = "0.23" # https://github.com/rustls/rustls/issues/1938
 rstest = "0.22"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "kolloch",
         "repo": "crate2nix",
-        "rev": "027440d39350aa45bf63d032320d59a1e24bc47b",
-        "sha256": "1mb2bhbzm4cjwfi5qwi9qqb11mlfwdwxjsi051sscxbf3yyibmyh",
+        "rev": "236f6addfd452a48be805819e3216af79e988fd5",
+        "sha256": "1cnq84c1bhhbn3blm31scrqsxw2bl1w67v6gpav01m0s2509klf5",
         "type": "tarball",
-        "url": "https://github.com/kolloch/crate2nix/archive/027440d39350aa45bf63d032320d59a1e24bc47b.tar.gz",
+        "url": "https://github.com/kolloch/crate2nix/archive/236f6addfd452a48be805819e3216af79e988fd5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ea780f3de2d169f982564128804841500e85e373",
-        "sha256": "18arqzwv00mwaps98rgmnxcksgr4rm1ivmzfpjfkpkbbndid3h3b",
+        "rev": "8b908192e64224420e2d59dfd9b2e4309e154c5d",
+        "sha256": "1yfsvb2cjinlydcmy8maaa2qafh2sqnn7h6mq80syzvr81li2kcy",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/ea780f3de2d169f982564128804841500e85e373.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/8b908192e64224420e2d59dfd9b2e4309e154c5d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/trino-lb/Cargo.toml
+++ b/trino-lb/Cargo.toml
@@ -39,7 +39,6 @@ rand.workspace = true
 redis.workspace = true
 regex.workspace = true
 reqwest.workspace = true
-rustls.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
 serde.workspace = true

--- a/trino-lb/src/main.rs
+++ b/trino-lb/src/main.rs
@@ -100,12 +100,6 @@ fn main() -> Result<(), MainError> {
 async fn start() -> Result<(), MainError> {
     let args = Args::parse();
 
-    // To prevent `no process-level CryptoProvider available -- call CryptoProvider::install_default() before this point`,
-    // see https://github.com/rustls/rustls/issues/1938 for details
-    rustls::crypto::aws_lc_rs::default_provider()
-        .install_default()
-        .map_err(|_| Error::InstallRustlsCryptoProvider {})?;
-
     let config = Config::read_from_file(&args.config_file)
         .await
         .context(ReadConfigSnafu)?;


### PR DESCRIPTION
Previously it failed with
```
Building src/lib.rs (hyper)
Running rustc --crate-name hyper src/lib.rs --out-dir target/lib -L dependency=target/deps --cap-lints allow -C debuginfo=2 -C codegen-units=1 --remap-path-prefix=/build=/ --extern bytes=/nix/store/r9q7jg4kcakimzmdmrrp3v9yv0gnay0d-rust_bytes-1.7.1-lib/lib/libbytes-96d5c02eba.rlib --extern futures_channel=/nix/store/65rb1hgm6x1zmnpkrzjprdns52carc3a-rust_futures-channel-0.3.30-lib/lib/libfutures_channel-88ea51625a.rlib --extern futures_core=/nix/store/f1na8ln5zza695zwx5kyfm7xf31qg1lw-rust_futures-core-0.3.30-lib/lib/libfutures_core-66ce7a7de0.rlib --extern futures_util=/nix/store/0pzp6jc3ksrx3f80cvfqz1zf7i60nd9c-rust_futures-util-0.3.30-lib/lib/libfutures_util-9029480c4c.rlib --extern h2=/nix/store/vb0z2s1vad00h12ha9lbhxzf3c8x1yfl-rust_h2-0.3.26-lib/lib/libh2-cad87fc98e.rlib --extern http=/nix/store/hkd9cdm0jpaf4fzf873v79l9bin8bv4b-rust_http-0.2.12-lib/lib/libhttp-fe937196bb.rlib --extern http_body=/nix/store/jn82crgy3a4q64f8q80gw2415h9fr7c4-rust_http-body-0.4.6-lib/lib/libhttp_body-c746c31ffc.rlib --extern httparse=/nix/store/1h6925wm61mmyjydmf1vhbj40am5wm9p-rust_httparse-1.9.4-lib/lib/libhttparse-d0b1b96ea3.rlib --extern httpdate=/nix/store/hzkhy4n0dx78lql6g236pbb2h4rc83kn-rust_httpdate-1.0.3-lib/lib/libhttpdate-9467fbc14e.rlib --extern itoa=/nix/store/ipbwhids48avwwx6l71pmj39gnhy3pn2-rust_itoa-1.0.11-lib/lib/libitoa-9e238235b8.rlib --extern pin_project_lite=/nix/store/vjsw7qh3z08w3r15zzbri31s97vwsxgn-rust_pin-project-lite-0.2.14-lib/lib/libpin_project_lite-effb2a00d1.rlib --extern socket2=/nix/store/fmrizb6daj0zsdjm66r95dckl6w4qica-rust_socket2-0.5.7-lib/lib/libsocket2-ab9b3d73e6.rlib --extern tokio=/nix/store/7q1hxlag1p9hm97fix3waa1gdyax8gak-rust_tokio-1.39.2-lib/lib/libtokio-d7d9e9fcdb.rlib --extern tower_service=/nix/store/hv0xybx4afq4gs4brlbjzh7f4rq1d0xw-rust_tower-service-0.3.3-lib/lib/libtower_service-210e699896.rlib --extern tracing=/nix/store/kqknc4y5gr70hwhcz8pzb94immrsw63v-rust_tracing-0.1.40-lib/lib/libtracing-7b428f955d.rlib --extern want=/nix/store/yw25fw9vls1cb1qzz2ysnkpl9gsrp3qa-rust_want-0.3.1-lib/lib/libwant-5ac888ddbb.rlib --cfg feature="client" --cfg feature="h2" --cfg feature="http1" --cfg feature="http2" --cfg feature="runtime" --cfg feature="socket2" --cfg feature="tcp" --edition 2018 -C metadata=1740203d35 -C extra-filename=-1740203d35 --crate-type lib --color always
Running phase: buildPhase
thread 'main' panicked at build.rs:59:5:
missing DEP_AWS_LC_ include
stack backtrace:
   0: rust_begin_unwind
   1: core::panicking::panic_fmt
   2: build_script_build::export_sys_vars
             at ./build.rs:59:5
   3: build_script_build::main
             at ./build.rs:24:5
   4: core::ops::function::FnOnce::call_once
             at /build/rustc-1.75.0-src/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
error: builder for '/nix/store/ngbn749pcd2ajyayzajyy0g6mx5xgh0n-rust_aws-lc-rs-1.8.1.drv' failed with exit code 101;
       last 10 log lines:
       > stack backtrace:
       >    0: rust_begin_unwind
       >    1: core::panicking::panic_fmt
       >    2: build_script_build::export_sys_vars
       >              at ./build.rs:59:5
       >    3: build_script_build::main
       >              at ./build.rs:24:5
       >    4: core::ops::function::FnOnce::call_once
       >              at /build/rustc-1.75.0-src/library/core/src/ops/function.rs:250:5
       > note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
       For full logs, run 'nix log /nix/store/ngbn749pcd2ajyayzajyy0g6mx5xgh0n-rust_aws-lc-rs-1.8.1.drv'.
error: 1 dependencies of derivation '/nix/store/c8z6y7bzz8kybp07wfkms37czkzbf41l-rust_trino-lb-0.3.0.drv' failed to build
error: 1 dependencies of derivation '/nix/store/kikgccq2ghxsqh37xic2xwwk56zm0wz6-all-workspace-members.drv' failed to build
error: 1 dependencies of derivation '/nix/store/6i4pgya7bbr7909a3a52f7fib8bx8146-trino-lb-base.json.drv' failed to build
error: 1 dependencies of derivation '/nix/store/v056jh419i7l26rj1nlg35jnv58jqibs-trino-lb-conf.json.drv' failed to build
error: 1 dependencies of derivation '/nix/store/myfnvylvg94wbgk3hizzv0a6g2abg5ks-stream-trino-lb-image-tag.drv' failed to build
error: 1 dependencies of derivation '/nix/store/8aaw3py1wqz903l0lcy9pbx1nyaxlh9d-listener-operator-docker.drv' failed to build
```