### PR TITLE
ci: Use fixed build action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - name: Build and (optionally) push container image
         id: build
-        uses: stackabletech/actions/build-container-image@ab97c67d79a79d9c6b0dc81b5dbe2fc5fd216a5a # v0.0.4
+        uses: stackabletech/actions/build-container-image@f589fce30aa5c1de94aa22d4e8e9b4b7f0810d40 # vx.x.x
         with:
           image-name: trino-lb
           image-index-manifest-tag: dev
@@ -73,7 +73,7 @@ jobs:
 
       # - name: Publish Container Image on docker.stackable.tech
       #   if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-      #   uses: stackabletech/actions/publish-image@ab97c67d79a79d9c6b0dc81b5dbe2fc5fd216a5a # v0.0.4
+      #   uses: stackabletech/actions/publish-image@f589fce30aa5c1de94aa22d4e8e9b4b7f0810d40 # vx.x.x
       #   with:
       #     image-registry-uri: docker.stackable.tech
       #     image-registry-username: github
@@ -84,7 +84,7 @@ jobs:
 
       - name: Publish Container Image on oci.stackable.tech
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: stackabletech/actions/publish-image@ab97c67d79a79d9c6b0dc81b5dbe2fc5fd216a5a # v0.0.4
+        uses: stackabletech/actions/publish-image@f589fce30aa5c1de94aa22d4e8e9b4b7f0810d40 # vx.x.x
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$stackable+github-action-build
@@ -106,7 +106,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       # - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-      #   uses: stackabletech/actions/publish-index-manifest@ab97c67d79a79d9c6b0dc81b5dbe2fc5fd216a5a # v0.0.4
+      #   uses: stackabletech/actions/publish-index-manifest@f589fce30aa5c1de94aa22d4e8e9b4b7f0810d40 # vx.x.x
       #   with:
       #     image-registry-uri: docker.stackable.tech
       #     image-registry-username: github
@@ -115,7 +115,7 @@ jobs:
       #     image-index-manifest-tag: dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@ab97c67d79a79d9c6b0dc81b5dbe2fc5fd216a5a # v0.0.4
+        uses: stackabletech/actions/publish-index-manifest@f589fce30aa5c1de94aa22d4e8e9b4b7f0810d40 # vx.x.x
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$stackable+github-action-build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - name: Build and (optionally) push container image
         id: build
-        uses: stackabletech/actions/build-container-image@f589fce30aa5c1de94aa22d4e8e9b4b7f0810d40 # vx.x.x
+        uses: stackabletech/actions/build-container-image@9bd13255f286e4b7a654617268abe1b2f37c3e0a # v0.0.5
         with:
           image-name: trino-lb
           image-index-manifest-tag: dev
@@ -76,7 +76,7 @@ jobs:
 
       # - name: Publish Container Image on docker.stackable.tech
       #   if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-      #   uses: stackabletech/actions/publish-image@f589fce30aa5c1de94aa22d4e8e9b4b7f0810d40 # vx.x.x
+      #   uses: stackabletech/actions/publish-image@9bd13255f286e4b7a654617268abe1b2f37c3e0a # v0.0.5
       #   with:
       #     image-registry-uri: docker.stackable.tech
       #     image-registry-username: github
@@ -87,7 +87,7 @@ jobs:
 
       - name: Publish Container Image on oci.stackable.tech
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: stackabletech/actions/publish-image@f589fce30aa5c1de94aa22d4e8e9b4b7f0810d40 # vx.x.x
+        uses: stackabletech/actions/publish-image@9bd13255f286e4b7a654617268abe1b2f37c3e0a # v0.0.5
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$stackable+github-action-build
@@ -109,7 +109,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       # - name: Publish and Sign Image Index Manifest to docker.stackable.tech
-      #   uses: stackabletech/actions/publish-index-manifest@f589fce30aa5c1de94aa22d4e8e9b4b7f0810d40 # vx.x.x
+      #   uses: stackabletech/actions/publish-index-manifest@9bd13255f286e4b7a654617268abe1b2f37c3e0a # v0.0.5
       #   with:
       #     image-registry-uri: docker.stackable.tech
       #     image-registry-username: github
@@ -118,7 +118,7 @@ jobs:
       #     image-index-manifest-tag: dev
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@f589fce30aa5c1de94aa22d4e8e9b4b7f0810d40 # vx.x.x
+        uses: stackabletech/actions/publish-index-manifest@9bd13255f286e4b7a654617268abe1b2f37c3e0a # v0.0.5
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$stackable+github-action-build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,8 @@
 name: Build pipeline
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 env:
   RUST_TOOLCHAIN_VERSION: "1.79.0"


### PR DESCRIPTION
- Use the fixed build action which loads the image into the docker store
- Deduplicate workflow runs