### PR TITLE
fix(docker): Add libpython3-dev package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.1] - 2025-03-03
+
+### Fixed
+
+- Fix the container image not containing the `libpython3-dev` package.
+  This prevented the startup of trino-lb ([#66]).
+
+[#66]: https://github.com/stackabletech/trino-lb/pull/66
+
 ## [0.4.0] - 2025-02-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Fix the container image not containing the `libpython3-dev` package.
-  This prevented the startup of trino-lb ([#66]).
+- Add the `libpython3-dev` package to the container image. This prevented the startup of trino-lb ([#66]).
 
 [#66]: https://github.com/stackabletech/trino-lb/pull/66
 

--- a/README.md
+++ b/README.md
@@ -17,17 +17,19 @@ A highly available load balancer with support for queueing, routing and auto-sca
   * [Stackable](./docs/scaling/stackable.md)
 
 ## Try it out locally
+
 The easiest way to use trino-lb is by using the available container image.
 Make sure you clone this repo and run the following command from the root directory of it.
 
 ### Without Trino clusters
+
 In case you don't have any Trino cluster at hand you can start trino-lb without any Trino cluster as follows:
 
 ```bash
 docker run -p 8080:8080 -v ./example-configs/simple-no-trino.yaml:/etc/trino-lb-config.yaml --rm oci.stackable.tech/stackable/trino-lb:0.4.0
 ```
 
-This starts trino-lb listening on http://127.0.0.1:8080.
+This starts trino-lb listening on <http://127.0.0.1:8080>.
 
 You can submit a test-query using [trino-cli](https://trino.io/docs/current/client/cli.html) by calling the following command and entering `select 42;`:
 
@@ -72,4 +74,5 @@ You can test this out by executing multiple long running queries in parallel.
 Also this is just the starting point without any routing, load-balancing or autoscaling. Read on the [design guide](./docs/design.md) on what trino-lb can do.
 
 ## Example configs
+
 Please have a look at the `example-configs` folder to get an inspiration on what you can configure.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Make sure you clone this repo and run the following command from the root direct
 In case you don't have any Trino cluster at hand you can start trino-lb without any Trino cluster as follows:
 
 ```bash
-docker run -p 8080:8080 -v ./example-configs/simple-no-trino.yaml:/etc/trino-lb-config.yaml --rm oci.stackable.tech/stackable/trino-lb:0.3.2
+docker run -p 8080:8080 -v ./example-configs/simple-no-trino.yaml:/etc/trino-lb-config.yaml --rm oci.stackable.tech/stackable/trino-lb:0.4.0
 ```
 
 This starts trino-lb listening on http://127.0.0.1:8080.
@@ -49,7 +49,7 @@ Afterwards start trino-lb using the following command.
 We are using self-signed certificates for testing purpose here.
 
 ```bash
-docker run -p 443:8443 -v ./example-configs/docker-simple-single-trino.yaml:/etc/trino-lb-config.yaml -v ./example-configs/self-signed-certs/:/self-signed-certs/ --rm oci.stackable.tech/stackable/trino-lb:0.3.2
+docker run -p 443:8443 -v ./example-configs/docker-simple-single-trino.yaml:/etc/trino-lb-config.yaml -v ./example-configs/self-signed-certs/:/self-signed-certs/ --rm oci.stackable.tech/stackable/trino-lb:0.4.0
 ```
 
 > [!NOTE]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,7 @@ FROM debian:bookworm-slim
 # Install python, needed for PythonScriptRouter
 # hadolint ignore=DL3008
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y python3 python3-pip && \
+    apt-get install --no-install-recommends -y python3 python3-pip libpython3-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # There are propably some users that want to use this libs in their PythonScriptRouter to e.g. make external HTTP calls


### PR DESCRIPTION
Previously we got
`trino-lb: error while loading shared libraries: libpython3.11.so.1.0: cannot open shared object file: No such file or directory`
