### PR TITLE
feat: Support configuring compression for OTEL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Support configuring compression for OTEL ([#70]).
+
+[#70]: https://github.com/stackabletech/trino-lb/pull/70
+
 ## [0.4.1] - 2025-03-03
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4084,6 +4084,7 @@ dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
  "bytes",
+ "flate2",
  "h2 0.4.7",
  "http 1.2.0",
  "http-body 1.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ number_prefix = "0.4"
 opentelemetry = "0.24"
 opentelemetry_sdk = { version = "0.24", features = ["rt-tokio"] }
 opentelemetry-http = "0.13"
-opentelemetry-otlp = { version = "0.17", features = ["serialize"] }
+opentelemetry-otlp = { version = "0.17", features = ["serialize", "gzip-tonic"] }
 opentelemetry-prometheus = "0.17"
 prometheus = "0.13"
 prusto = "0.5"

--- a/deploy/helm/trino-lb/configs/trino-lb-config.yaml
+++ b/deploy/helm/trino-lb/configs/trino-lb-config.yaml
@@ -15,9 +15,10 @@ trinoLb:
   refreshQueryCounterInterval: 30s # It is low for testing purpose and to get frequent running queries metrics
   tracing:
     enabled: true
-    # helm install jaeger jaegertracing/jaeger --set 'collector.service.otlp.grpc.name=otlp-grpc,collector.service.otlp.grpc.port=4317,collector.service.otlp.http.name=otlp-http,collector.service.otlp.http.port=4318'
+    # helm install jaeger jaegertracing/jaeger --set 'collector.service.otlp.grpc.name=otlp-grpc,collector.service.otlp.grpc.port=4317,collector.service.otlp.http.name=otlp-http,collector.service.otlp.http.port=4318,collector.cmdlineParams.collector\.grpc-server\.max-message-size=419430400'
     OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger-collector.default.svc.cluster.local:4317
     OTEL_EXPORTER_OTLP_PROTOCOL: Grpc
+    OTEL_EXPORTER_OTLP_COMPRESSION: Gzip # TODO: This might be renamed to gzip
     # In case endpoint and protocol are not set here, they will still be read from the env vars
     # OTEL_EXPORTER_OTLP_ENDPOINT and OTEL_EXPORTER_OTLP_PROTOCOL
 

--- a/trino-lb-core/src/config.rs
+++ b/trino-lb-core/src/config.rs
@@ -95,7 +95,7 @@ pub struct TrinoLbTracingConfig {
     pub otlp_protocol: Option<opentelemetry_otlp::Protocol>,
 
     /// TODO: Ideally [`opentelemetry_otlp::Compression`] would serialize and deserialize to
-    /// `gzip`. However, they currently de/ser to `Gzip`, which differs from [`opentelemetry_otlp::Compression::from_str`]
+    /// `gzip`. However, they currently de/ser to `Gzip`, which differs from `opentelemetry_otlp::Compression::from_str`
     /// We should raise an upstream issue
     #[serde(rename = "OTEL_EXPORTER_OTLP_COMPRESSION")]
     pub otlp_compression: Option<opentelemetry_otlp::Compression>,

--- a/trino-lb-core/src/config.rs
+++ b/trino-lb-core/src/config.rs
@@ -93,6 +93,12 @@ pub struct TrinoLbTracingConfig {
 
     #[serde(rename = "OTEL_EXPORTER_OTLP_PROTOCOL")]
     pub otlp_protocol: Option<opentelemetry_otlp::Protocol>,
+
+    /// TODO: Ideally [`opentelemetry_otlp::Compression`] would serialize and deserialize to
+    /// `gzip`. However, they currently de/ser to `Gzip`, which differs from [`opentelemetry_otlp::Compression::from_str`]
+    /// We should raise an upstream issue
+    #[serde(rename = "OTEL_EXPORTER_OTLP_COMPRESSION")]
+    pub otlp_compression: Option<opentelemetry_otlp::Compression>,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/trino-lb/src/tracing.rs
+++ b/trino-lb/src/tracing.rs
@@ -138,6 +138,9 @@ fn exporter(tracing_config: &TrinoLbTracingConfig) -> TonicExporterBuilder {
     if let Some(protocol) = tracing_config.otlp_protocol {
         exporter = exporter.with_protocol(protocol);
     }
+    if let Some(compression) = tracing_config.otlp_compression {
+        exporter = exporter.with_compression(compression);
+    }
 
     // In case endpoint and protocol are not set here, they will still be read from the env vars
     // OTEL_EXPORTER_OTLP_ENDPOINT and OTEL_EXPORTER_OTLP_PROTOCOL


### PR DESCRIPTION
Trying to resolve `OpenTelemetry trace error occurred. Exporter otlp encountered the following error(s): the grpc server returns error (Some resource has been exhausted): , detailed error message: grpc: received message larger than max (16576815 vs. 4194304)`..

Turns out after turning on gzip compression we than get `detailed error message: grpc: received message after decompression larger than max (8855098 vs. 4194304)` :joy: 