### PR TITLE
chore!: Bind to IPv4 only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 - BREAKING: Only bind to IPv4 (`0.0.0.0`) instead of IPv6 (`::`).
   On most Linux systems, binding to `::` dual-stacks, on Windows this would likely bind to IPv6 only.
   As a user reported that they run into `Address family not supported by protocol (os error 97)`, we now only bind to IPv4.
-  There was some attempt to make it portable work on IPv4 and IPv6 (optional), but that turned out to be a bigger story for later ([#XX]).
+  There was some attempt to make it portable work on IPv4 and IPv6 (optional), but that turned out to be a bigger story for later ([#91]).
 
 ### Fixed
 
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 [#68]: https://github.com/stackabletech/trino-lb/pull/68
 [#85]: https://github.com/stackabletech/trino-lb/pull/85
 [#86]: https://github.com/stackabletech/trino-lb/pull/86
+[#91]: https://github.com/stackabletech/trino-lb/pull/91
 
 ## [0.5.0] - 2025-03-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this project will be documented in this file.
 - The Stackable scaler now ensures that a `TrinoCluster` has changed to `ready` more than 5 seconds
   ago before marking it as `ready` ([#68]).
 - Emit less attributes in tracing to make logs easier readable ([#86]).
+- BREAKING: Only bind to IPv4 (`0.0.0.0`) instead of IPv6 (`::`).
+  On most Linux systems, binding to `::` dual-stacks, on Windows this would likely bind to IPv6 only.
+  As a user reported that they run into `Address family not supported by protocol (os error 97)`, we now only bind to IPv4.
+  There was some attempt to make it portable work on IPv4 and IPv6 (optional), but that turned out to be a bigger story for later ([#XX]).
 
 ### Fixed
 

--- a/trino-lb/src/http_server/mod.rs
+++ b/trino-lb/src/http_server/mod.rs
@@ -1,6 +1,6 @@
 use std::{
     fmt::Debug,
-    net::{Ipv6Addr, SocketAddr},
+    net::{Ipv4Addr, SocketAddr},
     path::PathBuf,
     sync::Arc,
     time::Duration,
@@ -77,7 +77,7 @@ pub async fn start_http_server(
         .route("/", get(|| async { Redirect::permanent("/metrics") }))
         .route("/metrics", get(metrics::get))
         .with_state(Arc::clone(&app_state));
-    let listen_addr = SocketAddr::from((Ipv6Addr::UNSPECIFIED, ports_config.metrics));
+    let listen_addr = SocketAddr::from((Ipv4Addr::UNSPECIFIED, ports_config.metrics));
     info!(%listen_addr, "Starting metrics exporter");
 
     let handle = Handle::new();
@@ -129,7 +129,7 @@ pub async fn start_http_server(
 
     if tls_config.enabled {
         // Start https server
-        let listen_addr = SocketAddr::from((Ipv6Addr::UNSPECIFIED, ports_config.https));
+        let listen_addr = SocketAddr::from((Ipv4Addr::UNSPECIFIED, ports_config.https));
         info!(%listen_addr, "Starting server");
 
         let cert_pem_file = tls_config.cert_pem_file.context(CertsMissingSnafu)?;
@@ -148,7 +148,7 @@ pub async fn start_http_server(
             .context(StartHttpServerSnafu)?;
     } else {
         // Start http server
-        let listen_addr = SocketAddr::from((Ipv6Addr::UNSPECIFIED, ports_config.http));
+        let listen_addr = SocketAddr::from((Ipv4Addr::UNSPECIFIED, ports_config.http));
         info!(%listen_addr, "Starting server");
 
         axum_server::bind(listen_addr)


### PR DESCRIPTION
IPv6 is a foreign word for some systems...
Proper IPv6 support is a follow-up