### PR TITLE
test: Fix tests by using new trino-cli path

### DIFF
--- a/tests/templates/kuttl/client-spooling/30-test-queries.yaml.j2
+++ b/tests/templates/kuttl/client-spooling/30-test-queries.yaml.j2
@@ -28,7 +28,7 @@ spec:
               QUERY="select count(*) from tpch.sf1.customer"
 
               for COORDINATOR in "${COORDINATORS[@]}"; do
-                  echo "$QUERY" | java -jar trino-cli-executable.jar --server $COORDINATOR --insecure --user $TRINO_USER --password
+                  echo "$QUERY" | /stackable/trino-cli/trino-cli --server $COORDINATOR --insecure --user $TRINO_USER --password
               done
 
               # Send multiple queries in parallel to trino-lb
@@ -38,7 +38,7 @@ spec:
               pids=()
 
               for ((i = 1; i <= NUM_REQUESTS; i++)); do
-                  echo "$QUERY" | java -jar trino-cli-executable.jar --server $TRINO_LB_ADDRESS --insecure --user $TRINO_USER --password &
+                  echo "$QUERY" | /stackable/trino-cli/trino-cli --server $TRINO_LB_ADDRESS --insecure --user $TRINO_USER --password &
                   pids+=("$!")
               done
 
@@ -59,7 +59,7 @@ spec:
                   echo "Running query with big result set against $COORDINATOR"
                   ROW_COUNT=$(
                       echo "$BIG_RESULT_QUERY" | \
-                      java -jar trino-cli-executable.jar \
+                      /stackable/trino-cli/trino-cli \
                           --server "$COORDINATOR" \
                           --insecure \
                           --user "$TRINO_USER" \

--- a/tests/templates/kuttl/smoke/30-test-queries.yaml.j2
+++ b/tests/templates/kuttl/smoke/30-test-queries.yaml.j2
@@ -28,7 +28,7 @@ spec:
               QUERY="select count(*) from tpch.sf1.customer"
 
               for COORDINATOR in "${COORDINATORS[@]}"; do
-                  echo "$QUERY" | java -jar trino-cli-executable.jar --server $COORDINATOR --insecure --user $TRINO_USER --password
+                  echo "$QUERY" | /stackable/trino-cli/trino-cli --server $COORDINATOR --insecure --user $TRINO_USER --password
               done
 
               # Send multiple queries in parallel to trino-lb
@@ -38,7 +38,7 @@ spec:
               pids=()
 
               for ((i = 1; i <= NUM_REQUESTS; i++)); do
-                  echo "$QUERY" | java -jar trino-cli-executable.jar --server $TRINO_LB_ADDRESS --insecure --user $TRINO_USER --password &
+                  echo "$QUERY" | /stackable/trino-cli/trino-cli --server $TRINO_LB_ADDRESS --insecure --user $TRINO_USER --password &
                   pids+=("$!")
               done
 

--- a/tests/templates/kuttl/smoke/50-test-routing.yaml.j2
+++ b/tests/templates/kuttl/smoke/50-test-routing.yaml.j2
@@ -20,15 +20,15 @@ spec:
               COORDINATOR_NAME_QUERY="select regexp_extract(url_extract_host(http_uri), '[a-z0-9-]+') from "system".runtime.nodes where coordinator = true"
 
               # admin lands in s
-              echo "$COORDINATOR_NAME_QUERY" | TRINO_PASSWORD=adminadmin java -jar trino-cli-executable.jar --server $TRINO_LB_ADDRESS --insecure --user admin --password | grep -qx '"trino-s-1-coordinator-default-0"' || exit 1
+              echo "$COORDINATOR_NAME_QUERY" | TRINO_PASSWORD=adminadmin /stackable/trino-cli/trino-cli --server $TRINO_LB_ADDRESS --insecure --user admin --password | grep -qx '"trino-s-1-coordinator-default-0"' || exit 1
               # alice lands in s
-              echo "$COORDINATOR_NAME_QUERY" | TRINO_PASSWORD=alicealice java -jar trino-cli-executable.jar --server $TRINO_LB_ADDRESS --insecure --user alice --password | grep -qx '"trino-s-1-coordinator-default-0"' || exit 1
+              echo "$COORDINATOR_NAME_QUERY" | TRINO_PASSWORD=alicealice /stackable/trino-cli/trino-cli --server $TRINO_LB_ADDRESS --insecure --user alice --password | grep -qx '"trino-s-1-coordinator-default-0"' || exit 1
               # bob lands in m
-              echo "$COORDINATOR_NAME_QUERY" | TRINO_PASSWORD=bobbob java -jar trino-cli-executable.jar --server $TRINO_LB_ADDRESS --insecure --user bob --password | grep -qx '"trino-m-1-coordinator-default-0"' || exit 1
+              echo "$COORDINATOR_NAME_QUERY" | TRINO_PASSWORD=bobbob /stackable/trino-cli/trino-cli --server $TRINO_LB_ADDRESS --insecure --user bob --password | grep -qx '"trino-m-1-coordinator-default-0"' || exit 1
 
               # We can also set client tags explicitly
-              echo "$COORDINATOR_NAME_QUERY" | TRINO_PASSWORD=adminadmin java -jar trino-cli-executable.jar --server $TRINO_LB_ADDRESS --insecure --user admin --password --client-tags=s | grep -qx '"trino-s-1-coordinator-default-0"' || exit 1
-              echo "$COORDINATOR_NAME_QUERY" | TRINO_PASSWORD=adminadmin java -jar trino-cli-executable.jar --server $TRINO_LB_ADDRESS --insecure --user admin --password --client-tags=m | grep -qx '"trino-m-1-coordinator-default-0"' || exit 1
+              echo "$COORDINATOR_NAME_QUERY" | TRINO_PASSWORD=adminadmin /stackable/trino-cli/trino-cli --server $TRINO_LB_ADDRESS --insecure --user admin --password --client-tags=s | grep -qx '"trino-s-1-coordinator-default-0"' || exit 1
+              echo "$COORDINATOR_NAME_QUERY" | TRINO_PASSWORD=adminadmin /stackable/trino-cli/trino-cli --server $TRINO_LB_ADDRESS --insecure --user admin --password --client-tags=m | grep -qx '"trino-m-1-coordinator-default-0"' || exit 1
 
               echo "All queries completed successfully."
       restartPolicy: OnFailure

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -3,6 +3,7 @@ dimensions:
   - name: trino-lb
     values:
       - oci.stackable.tech/stackable/trino-lb:dev
+      # - oci.stackable.tech/stackable/trino-lb:0.6.0
       # - foo:bar
   - name: trino
     values:


### PR DESCRIPTION
```
--- PASS: kuttl (470.08s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/smoke_trino-lb-oci.stackable.tech_stackable_trino-lb_dev_trino-477_persistence-inMemory (96.30s)
        --- PASS: kuttl/harness/client-spooling_trino-lb-oci.stackable.tech_stackable_trino-lb_dev_trino-477_client-spooling-retrieval-mode-STORAGE (236.52s)
        --- PASS: kuttl/harness/smoke_trino-lb-oci.stackable.tech_stackable_trino-lb_dev_trino-477_persistence-redis (154.70s)
        --- PASS: kuttl/harness/smoke_trino-lb-oci.stackable.tech_stackable_trino-lb_dev_trino-477_persistence-postgres (133.46s)
        --- PASS: kuttl/harness/client-spooling_trino-lb-oci.stackable.tech_stackable_trino-lb_dev_trino-477_client-spooling-retrieval-mode-COORDINATOR_PROXY (233.55s)
PASS
```