### PR TITLE
ci: Rename action publish-index-manifest -> publish-image-index-manifest

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -102,7 +102,7 @@ jobs:
           persist-credentials: false
 
       - name: Publish and Sign Image Index Manifest to oci.stackable.tech
-        uses: stackabletech/actions/publish-index-manifest@a14cbd08d9e034e2361ea9205b32aff0491885db # v0.15.0
+        uses: stackabletech/actions/publish-image-index-manifest@a14cbd08d9e034e2361ea9205b32aff0491885db # v0.15.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$stackable+github-action-build


### PR DESCRIPTION
The action was renamed between 0.0.6 and 0.15.0.