### PR TITLE
chore: Release 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Switch from the older `prusto` crate to the forked `trino-rust-client` ([#116]).
+- Switch from the older (forked) `prusto` crate to `trino-rust-client` ([#116]).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-08-03
+
 ### Changed
 
 - Switch from the older `prusto` crate to the forked `trino-rust-client` ([#116]).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4142,7 +4142,7 @@ dependencies = [
 
 [[package]]
 name = "trino-lb"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "askama",
  "axum",
@@ -4192,7 +4192,7 @@ dependencies = [
 
 [[package]]
 name = "trino-lb-bench"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "clap",
  "futures",
@@ -4204,7 +4204,7 @@ dependencies = [
 
 [[package]]
 name = "trino-lb-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "http",
@@ -4227,7 +4227,7 @@ dependencies = [
 
 [[package]]
 name = "trino-lb-persistence"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bincode",
  "enum_dispatch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Stackable GmbH <info@stackable.tech>"]
 license = "Apache-2.0"
 edition = "2024"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Make sure you clone this repo and run the following command from the root direct
 In case you don't have any Trino cluster at hand you can start trino-lb without any Trino cluster as follows:
 
 ```bash
-docker run -p 8080:8080 -v ./example-configs/simple-no-trino.yaml:/etc/trino-lb-config.yaml --rm oci.stackable.tech/stackable/trino-lb:0.6.0
+docker run -p 8080:8080 -v ./example-configs/simple-no-trino.yaml:/etc/trino-lb-config.yaml --rm oci.stackable.tech/stackable/trino-lb:0.7.0
 ```
 
 This starts trino-lb listening on <http://127.0.0.1:8080>.
@@ -52,7 +52,7 @@ Afterwards start trino-lb using the following command.
 We are using self-signed certificates for testing purpose here.
 
 ```bash
-docker run -p 443:8443 -v ./example-configs/docker-simple-single-trino.yaml:/etc/trino-lb-config.yaml -v ./example-configs/self-signed-certs/:/self-signed-certs/ --rm oci.stackable.tech/stackable/trino-lb:0.6.0
+docker run -p 443:8443 -v ./example-configs/docker-simple-single-trino.yaml:/etc/trino-lb-config.yaml -v ./example-configs/self-signed-certs/:/self-signed-certs/ --rm oci.stackable.tech/stackable/trino-lb:0.7.0
 ```
 
 > [!NOTE]

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -3,7 +3,7 @@ dimensions:
   - name: trino-lb
     values:
       - oci.stackable.tech/stackable/trino-lb:dev
-      # - oci.stackable.tech/stackable/trino-lb:0.6.0
+      # - oci.stackable.tech/stackable/trino-lb:0.7.0
       # - foo:bar
   - name: trino
     values:


### PR DESCRIPTION
### Changed

- Switch from the older (forked) `prusto` crate to `trino-rust-client` ([#116]).

### Fixed

- Handle Redis connection errors (e.g. broken pipe during master failover) gracefully instead of panicking.
  Previously, `get_queued_query_count` would `.unwrap()` on the Redis result, causing a panic that poisoned
  the metrics `RwLock`, cascading into further panics and leaving pods unresponsive ([#111]).
- Point the forwarding related headers (`Host`, `X-Forwarded-Host`, `X-Forwarded-Proto` and
  `X-Forwarded-Port`) of proxied client requests at the configured `externalEndpoint` of the Trino
  cluster. Trino builds the absolute URLs it hands out to clients from these headers, so previously
  they pointed at trino-lb. Most notably this broke the OAuth 2.0 flow: Trino put the trino-lb
  address into the `x_redirect_server` and `x_token_server` of its `WWW-Authenticate` challenge, so
  clients were sent to `https://<trino-lb>/oauth2/token/{id}`, which trino-lb answered with a `404`.
  The RFC 7239 `Forwarded` header is now removed as well, as it takes precedence over the
  `X-Forwarded-*` headers. This is a no-op for Trino clusters without an `externalEndpoint` ([#119]).

[#111]: https://github.com/stackabletech/trino-lb/pull/111
[#116]: https://github.com/stackabletech/trino-lb/pull/116
[#119]: https://github.com/stackabletech/trino-lb/pull/119